### PR TITLE
Add an option to selectivly ufurl the links

### DIFF
--- a/app/Console/Commands/pickPairs.php
+++ b/app/Console/Commands/pickPairs.php
@@ -54,8 +54,8 @@ class pickPairs extends Command
                 'random'   => Suggestion::where('category', 'random')->inRandomOrder()->first(),
             ];
 
-            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm')->with('pair', $pair));
-            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm-suggestions')->with($suggestions));
+            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm')->with('pair', $pair), $unfurl = true);
+            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm-suggestions')->with($suggestions), $unfurl = false);
         }
 
         $upcomingIds   = Pool::inRandomOrder()->limit(3)->pluck('member_id')->toArray();

--- a/app/Console/Commands/pickPairs.php
+++ b/app/Console/Commands/pickPairs.php
@@ -54,8 +54,8 @@ class pickPairs extends Command
                 'random'   => Suggestion::where('category', 'random')->inRandomOrder()->first(),
             ];
 
-            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm')->with('pair', $pair), $unfurl = true);
-            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm-suggestions')->with($suggestions), $unfurl = false);
+            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm')->with('pair', $pair), true);
+            $slack->sendPrivateMessage($pair, view('slack-messages.private-dm-suggestions')->with($suggestions), false);
         }
 
         $upcomingIds   = Pool::inRandomOrder()->limit(3)->pluck('member_id')->toArray();

--- a/app/Services/Slack.php
+++ b/app/Services/Slack.php
@@ -47,7 +47,7 @@ class Slack
 
         $userSlackIds = implode(',', $userSlackIds);
 
-        $response = json_decode($this->doCurl($apiUrl, ['users' => $userSlackIds], $headers = []));
+        $response = json_decode($this->doCurl($apiUrl, ['users' => $userSlackIds]));
         $groupId  = $response->group->id;
 
         return $this->sendToChannel($groupId, $message, $unfurl);

--- a/app/Services/Slack.php
+++ b/app/Services/Slack.php
@@ -16,7 +16,6 @@ class Slack
     {
         $postData['token']        = $this->token;
         $postData['as_user']      = 'true';
-        $postData['unfurl_links'] = 'false';
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -37,7 +36,7 @@ class Slack
         return $server_output;
     }
 
-    public function sendPrivateMessage($members, $message)
+    public function sendPrivateMessage($members, $message, $unfurl = true)
     {
         $apiUrl = 'https://slack.com/api/mpim.open';
 
@@ -48,17 +47,21 @@ class Slack
 
         $userSlackIds = implode(',', $userSlackIds);
 
-        $response = json_decode($this->doCurl($apiUrl, ['users' => $userSlackIds]));
+        $response = json_decode($this->doCurl($apiUrl, ['users' => $userSlackIds], $headers = []));
         $groupId  = $response->group->id;
 
-        return $this->sendToChannel($groupId, $message);
+        return $this->sendToChannel($groupId, $message, $unfurl);
     }
 
-    public function sendToChannel($channel, $message)
+    public function sendToChannel($channel, $message, $unfurl = true)
     {
         // Send the message
         $apiUrl = 'https://slack.com/api/chat.postMessage';
-        return json_decode($this->doCurl($apiUrl, ['channel' => $channel, 'text' => $message]));
+        return json_decode($this->doCurl($apiUrl, [
+            'channel'      => $channel,
+            'text'         => $message,
+            'unfurl_links' => $unfurl ? 'true' : 'false',
+        ]));
     }
 
     public function sendReceipt($person, $file, $comment)


### PR DESCRIPTION
Before hand the Cupid private messages had the gif auto expanded and also the suggestions list.

Split the two messages and have the for of the expansion on the gif message and non expand on the suggestion message