### PR TITLE
Added a new URL field for Suggestions

### DIFF
--- a/app/Models/Suggestion.php
+++ b/app/Models/Suggestion.php
@@ -8,4 +8,9 @@ class Suggestion extends Model
 {
     protected $table = 'suggestions';
 
+    protected $fillable = [
+        'category',
+        'description',
+        'url'
+    ];
 }

--- a/database/migrations/2017_09_07_061855_add_birthday_field.php
+++ b/database/migrations/2017_09_07_061855_add_birthday_field.php
@@ -27,7 +27,7 @@ class AddBirthdayField extends Migration
      */
     public function down()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('members', function (Blueprint $table) {
             $table->dropColumn('birthday');
         });
     }

--- a/database/migrations/2017_09_26_101759_alter_suggestions_add_url_field.php
+++ b/database/migrations/2017_09_26_101759_alter_suggestions_add_url_field.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterSuggestionsAddUrlField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('suggestions', function (Blueprint $table) {
+            // NOTE: Length of field 2083 based on lowest denominator of max length URL supported by browser
+            // For more info: https://boutell.com/newfaq/misc/urllength.html
+            $table->string('url', 2083)->after('description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('suggestions', function (Blueprint $table) {
+            $table->dropColumn('url');
+        });
+    }
+}

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -678,10 +678,20 @@ body{
 
 #section3 a{
     text-decoration: none;
-    color: white;
+    color: #FD5068;
 }
 
-.shuffle-btn{
+#section3 a:hover {
+    text-decoration: wavy;
+    color: #FD5090;
+}
+
+#section3 .shuffle-btn,
+#section3 .shuffle-btn:hover {
+    color: #FFFFFF;
+}
+
+.shuffle-btn {
     width: 195px;
     background-color: #FD5068;
     height: 45px;
@@ -696,7 +706,7 @@ body{
     transition: background-color 0.2s ease;
 }
 
-.shuffle-btn:hover{
+.shuffle-btn:hover {
     background-color: #FD5090;
 }
 

--- a/resources/views/sections/suggestions.blade.php
+++ b/resources/views/sections/suggestions.blade.php
@@ -9,16 +9,28 @@
             <h2>Food 🍕</h2>
             <p>{{ $food->description }}</p>
 
+            @if(empty($food->url) === false)
+                <a href="{{ $food->url }}" target="_blank">See more...</a>
+            @endif
+
         </div>
 
         <div class="text-container">
             <h2>Activity 🚲</h2>
             <p>{{ $activity->description }}</p>
+
+            @if(empty($activity->url) === false)
+                <a href="{{ $activity->url }}" target="_blank">See more...</a>
+            @endif
         </div>
 
         <div class="text-container">
             <h2>Random 👑</h2>
             <p>{{ $random->description }}</p>
+
+            @if(empty($random->url) === false)
+                <a href="{{ $random->url }}" target="_blank">See more...</a>
+            @endif
         </div>
 
     </div>

--- a/resources/views/sections/suggestions.blade.php
+++ b/resources/views/sections/suggestions.blade.php
@@ -10,7 +10,7 @@
             <p>{{ $food->description }}</p>
 
             @if(empty($food->url) === false)
-                <a href="{{ $food->url }}" target="_blank">See more...</a>
+                <a href="{{ $food->url }}" target="_blank">🌎 More details</a>
             @endif
 
         </div>
@@ -20,7 +20,7 @@
             <p>{{ $activity->description }}</p>
 
             @if(empty($activity->url) === false)
-                <a href="{{ $activity->url }}" target="_blank">See more...</a>
+                <a href="{{ $activity->url }}" target="_blank">🌍 More details</a>
             @endif
         </div>
 
@@ -29,7 +29,7 @@
             <p>{{ $random->description }}</p>
 
             @if(empty($random->url) === false)
-                <a href="{{ $random->url }}" target="_blank">See more...</a>
+                <a href="{{ $random->url }}" target="_blank">🌏 More details</a>
             @endif
         </div>
 


### PR DESCRIPTION
Added an extra field for Suggestion models to store URLs separate to the description.
 - Updated Suggestion view to cater for newly added field and updated model to allow editing of the Suggestion fields.
 - Also updated the birthday migration to correctly remove the birthday field from the members table.

@yswery I created a MySQL query to update all existing suggestions and split out the url from the description and correctly store the url for each. I've tested this locally. I've also attached a SELECT query for you to check what it should look like `before` running the update:
`SELECT` to test before
```sql
SELECT
    suggestions.description,
    split.description,
    split.url
FROM suggestions
INNER JOIN (
    SELECT
        id,
        SUBSTRING_INDEX(SUBSTRING_INDEX(description, 'http', 1), 'http', -1) AS description,
        TRIM( SUBSTR(description, LOCATE('http', description)) ) AS url
    FROM suggestions
) as split
    ON split.id = suggestions.id;
```

`UPDATE` to split fields
```sql
UPDATE suggestions main
INNER JOIN (
    SELECT
        id,
        SUBSTRING_INDEX(SUBSTRING_INDEX(description, 'http', 1), 'http', -1) AS description,
        TRIM( SUBSTR(description, LOCATE('http', description)) ) AS url
    FROM suggestions
) as split
    ON split.id = main.id
SET main.description = split.description,
    main.url = split.url;
```


Local Sample:
<img width="1387" alt="match_magic" src="https://user-images.githubusercontent.com/20937194/30834046-fc8107dc-a2ad-11e7-8d79-bf160ce2ca4f.png">
